### PR TITLE
better support for mac key variants

### DIFF
--- a/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
+++ b/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { MouseIcon } from '@patternfly/react-icons';
 import './Shortcut.scss';
 
@@ -7,10 +8,10 @@ interface ShortcutProps {
   alt?: boolean;
   click?: boolean;
   ctrl?: boolean;
+  ctrlCmd?: boolean;
   drag?: boolean;
   hover?: boolean;
   keyName?: string;
-  macCtrl?: boolean;
   rightClick?: boolean;
   shift?: boolean;
 }
@@ -23,30 +24,34 @@ const Command: React.FC = ({ children }) => (
 
 const Shortcut: React.FC<ShortcutProps> = ({
   children,
-  ctrl,
-  shift,
   alt,
-  keyName,
-  drag,
   click,
-  rightClick,
+  ctrl,
+  ctrlCmd,
+  drag,
   hover,
-  macCtrl,
+  keyName,
+  rightClick,
+  shift,
 }) => {
   const isMac = window.navigator.platform.includes('Mac');
   return (
     <tr>
       <td className="ocs-shortcut__cell">
-        {((!isMac && ctrl) || macCtrl) && <Command>Ctrl</Command>}
+        {(ctrl || (!isMac && ctrlCmd)) && <Command>Ctrl</Command>}
         {alt && <Command>{isMac ? '⌥ Opt' : 'Alt'}</Command>}
         {shift && <Command>Shift</Command>}
-        {isMac && ctrl && <Command>⌘ Cmd</Command>}
+        {isMac && ctrlCmd && <Command>⌘ Cmd</Command>}
         {hover && (
           <Command>
             <MouseIcon /> Hover
           </Command>
         )}
-        {keyName && <Command>{keyName.toUpperCase()}</Command>}
+        {keyName && (
+          <Command>
+            {keyName.length === 1 ? keyName.toUpperCase() : _.startCase(keyName.toLowerCase())}
+          </Command>
+        )}
         {drag && (
           <Command>
             <MouseIcon /> Drag

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -710,10 +710,10 @@ const EditYAML_ = connect(stateToProps)(
                           aria-label="Shortcuts"
                           bodyContent={
                             <ShortcutTable>
-                              <Shortcut macCtrl keyName="space">
+                              <Shortcut ctrl keyName="space">
                                 Use Ctrl + Space to activate auto complete.
                               </Shortcut>
-                              <Shortcut ctrl shift keyName="o">
+                              <Shortcut ctrlCmd shift keyName="o">
                                 Use Shift + {isMac ? 'Command' : 'Ctrl'} + O for document outlining.
                               </Shortcut>
                               <Shortcut hover>


### PR DESCRIPTION
`ctrl` is always `ctrl` on both windows and mac
`ctrlCmd` is a smart switch between `ctrl` on windows and `cmd` cmd on mac.

Also updates the `keyName` display to always be `Pascal Case`.