### PR TITLE
Fix bug where search background doesn't appear

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -186,6 +186,12 @@ h6 {
 .pf-c-chip-group.pf-m-toolbar {
   margin-bottom: var(--pf-global--spacer--xs);
 }
+
+// Fix bug where search background image doesn't appear
+.pf-c-form-control.pf-m-search {
+  --pf-c-form-control--m-search--BackgroundSize: 1rem 1rem;
+}
+
 // PF components that calculate their correct height based on --pf-global--FontSize--md: 1rem
 .pf-c-modal-box,
 .pf-c-switch {


### PR DESCRIPTION
@rebeccaalpert, this fixes the search background image not showing.  The bug occurs because we override `--pf-global--FontSize--md` with the value of a SASS variable.  That SASS variable does not get parsed in `form-control.css` since it is a CSS file and not an SCSS file.

<img width="396" alt="Screen Shot 2020-05-11 at 4 21 51 PM" src="https://user-images.githubusercontent.com/895728/81608521-711f0780-93a4-11ea-82aa-1c5ac622595c.png">
